### PR TITLE
Make EMP affect only one drone

### DIFF
--- a/src/main/java/bluevista/fpvracing/client/input/keybinds/EMPKeybind.java
+++ b/src/main/java/bluevista/fpvracing/client/input/keybinds/EMPKeybind.java
@@ -11,14 +11,29 @@ import net.minecraft.client.options.KeyBinding;
 import net.minecraft.client.util.InputUtil;
 import org.lwjgl.glfw.GLFW;
 
+/**
+ * The EMP keybinding class sets up the keybinding (default key: o)
+ * and also handles triggering of the keybinding. When the keybinding
+ * is triggered, it sends a packet to the server using {@link EMPC2S}.
+ */
 @Environment(EnvType.CLIENT)
 public class EMPKeybind {
     private static KeyBinding key;
 
+    /**
+     * The callback for the keybinding. It triggers
+     * when the player presses the EMP keybinding.
+     * @param client the client
+     */
     public static void callback(MinecraftClient client) {
         if (key.wasPressed()) EMPC2S.send();
     }
 
+    /**
+     * Registers the keybinding in {@link bluevista.fpvracing.client.ClientInitializer}.
+     * Also sets up the language identifier which is translated in the en_us.json file
+     * within assets/.
+     */
     public static void register() {
         key = new KeyBinding(
                 "key." + ServerInitializer.MODID + ".emp",

--- a/src/main/java/bluevista/fpvracing/client/input/keybinds/EMPKeybind.java
+++ b/src/main/java/bluevista/fpvracing/client/input/keybinds/EMPKeybind.java
@@ -16,7 +16,7 @@ public class EMPKeybind {
     private static KeyBinding key;
 
     public static void callback(MinecraftClient client) {
-        if (key.wasPressed()) EMPC2S.send(500);
+        if (key.wasPressed()) EMPC2S.send();
     }
 
     public static void register() {

--- a/src/main/java/bluevista/fpvracing/network/keybinds/EMPC2S.java
+++ b/src/main/java/bluevista/fpvracing/network/keybinds/EMPC2S.java
@@ -3,60 +3,43 @@ package bluevista.fpvracing.network.keybinds;
 import bluevista.fpvracing.server.ServerInitializer;
 import bluevista.fpvracing.server.ServerTick;
 import bluevista.fpvracing.server.entities.DroneEntity;
+import bluevista.fpvracing.server.items.TransmitterItem;
 import io.netty.buffer.Unpooled;
 import net.fabricmc.fabric.api.network.ClientSidePacketRegistry;
 import net.fabricmc.fabric.api.network.PacketContext;
 import net.fabricmc.fabric.api.network.ServerSidePacketRegistry;
-import net.minecraft.entity.Entity;
 import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.item.ItemStack;
 import net.minecraft.network.PacketByteBuf;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.text.TranslatableText;
 import net.minecraft.util.Identifier;
 
-import java.util.List;
-
 public class EMPC2S {
     public static final Identifier PACKET_ID = new Identifier(ServerInitializer.MODID, "emp_c2s");
 
     public static void accept(PacketContext context, PacketByteBuf buf) {
-        PlayerEntity p = context.getPlayer();
-        int r = buf.readInt();
+        PlayerEntity playerEntity = context.getPlayer();
 
         context.getTaskQueue().execute(() -> {
-            int kill = 0;
+            ServerPlayerEntity serverPlayerEntity = (ServerPlayerEntity) playerEntity;
+            ItemStack itemStack = serverPlayerEntity.getMainHandStack();
 
-            ServerPlayerEntity sp = (ServerPlayerEntity) p;
-            if (ServerTick.isInGoggles(sp)) {
-                sp.getCameraEntity().kill();
-                sp.getServerWorld().removeEntity(sp.getCameraEntity());
-                ServerTick.resetView(sp);
-                kill++;
-            }
+            if (itemStack.getItem() instanceof TransmitterItem) {
+                DroneEntity drone = TransmitterItem.droneFromTransmitter(itemStack, serverPlayerEntity);
 
-            List<Entity> entities = p.getEntityWorld().getOtherEntities(p, p.getBoundingBox().expand(r));
-            for (Entity e : entities) {
-                if (e instanceof DroneEntity) {
-                    DroneEntity drone = (DroneEntity) e;
+                if (drone != null) {
                     drone.kill();
-                    kill++;
+                    serverPlayerEntity.getServerWorld().removeEntity(drone);
+                    ServerTick.resetView(serverPlayerEntity);
+                    serverPlayerEntity.sendMessage(new TranslatableText("Destroyed drone"), false);
                 }
             }
-
-            String t;
-            if (kill == 1) t = "Destroyed 1 drone";
-            else t = "Destroyed " + kill + " drones";
-
-            List<? extends PlayerEntity> players = context.getPlayer().getEntityWorld().getPlayers();
-            for (PlayerEntity player : players)
-                player.sendMessage(new TranslatableText(t), false);
         });
     }
 
-    public static void send(int r) {
-        PacketByteBuf buf = new PacketByteBuf(Unpooled.buffer());
-        buf.writeInt(r);
-        ClientSidePacketRegistry.INSTANCE.sendToServer(PACKET_ID, buf);
+    public static void send() {
+        ClientSidePacketRegistry.INSTANCE.sendToServer(PACKET_ID, new PacketByteBuf(Unpooled.buffer()));
     }
 
     public static void register() {

--- a/src/main/java/bluevista/fpvracing/network/keybinds/EMPC2S.java
+++ b/src/main/java/bluevista/fpvracing/network/keybinds/EMPC2S.java
@@ -15,9 +15,19 @@ import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.text.TranslatableText;
 import net.minecraft.util.Identifier;
 
+/**
+ * This packet is sent whenever the player types the EMP command or presses
+ * the EMP keybinding. There really isn't any information to include since
+ * receiving this packet only performs one operation involving no data.
+ */
 public class EMPC2S {
     public static final Identifier PACKET_ID = new Identifier(ServerInitializer.MODID, "emp_c2s");
 
+    /**
+     * Accepts the packet. No information is really sent besides the current {@link PlayerEntity}.
+     * @param context the packet context
+     * @param buf an empty buffer
+     */
     public static void accept(PacketContext context, PacketByteBuf buf) {
         PlayerEntity playerEntity = context.getPlayer();
 
@@ -38,10 +48,17 @@ public class EMPC2S {
         });
     }
 
+    /**
+     * Sends the packet to the server. No information is passed in or included
+     * within the {@link PacketByteBuf}.
+     */
     public static void send() {
         ClientSidePacketRegistry.INSTANCE.sendToServer(PACKET_ID, new PacketByteBuf(Unpooled.buffer()));
     }
 
+    /**
+     * Registers the packet in {@link ServerInitializer}.
+     */
     public static void register() {
         ServerSidePacketRegistry.INSTANCE.register(PACKET_ID, EMPC2S::accept);
     }


### PR DESCRIPTION
Modified the behavior of the EMP packet to only kill the drone associated with the player's transmitter item. Also prints the message "Drone destroyed" whenever a drone is killed by the player. Also documented EMPC2S.class and EMPKeybind.class while I was already working on those.